### PR TITLE
Update version call - fixes importlib error

### DIFF
--- a/src/faqtory/cli.py
+++ b/src/faqtory/cli.py
@@ -47,7 +47,7 @@ FAQ_TEMPLATE = """
 
 
 @click.group()
-@click.version_option(version("faq"))
+@click.version_option(version("faqtory"))
 def run():
     pass
 


### PR DESCRIPTION
I get an importlib error as there's no module called `faq`. Changing to `faqtory` fixes it. I'm assuming this is what's required.