### PR TITLE
Add missing dash for --no-overwrite

### DIFF
--- a/src/faqtory/cli.py
+++ b/src/faqtory/cli.py
@@ -101,7 +101,7 @@ def run():
 )
 @click.option("--faq-url", help="FAQ URL", default=FAQ_URL, metavar="PATH")
 @click.option(
-    "--overwrite/-no-overwrite",
+    "--overwrite/--no-overwrite",
     help="Overwrite files if they exist",
     default=False,
 )


### PR DESCRIPTION
I don't know much of click, but this seemed like an error.