### PR TITLE
fix: remove punctuation from question slug

### DIFF
--- a/src/faqtory/models.py
+++ b/src/faqtory/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import string
 from pathlib import Path
 from typing import List
 
@@ -24,7 +25,12 @@ class Question(BaseModel):
         Returns:
             str: Slug suitable for use in an anchor.
         """
-        return self.title.lower().replace(" ", "-").replace("?", "").replace(".", "")
+        chars_to_remove = string.punctuation
+        chars_to_remove = chars_to_remove.replace("-", "").replace("_", "")
+        slug = self.title.lower()
+        slug = slug.translate(str.maketrans("", "", chars_to_remove))
+        slug = slug.replace(" ", "-")
+        return slug
 
     @classmethod
     def read(cls, path: Path) -> "Question":


### PR DESCRIPTION
Remove punctuation from questions slugs apart from hyphens and underscores, as discussed in https://github.com/Textualize/textual/pull/4027

>[!IMPORTANT]
> Markdown converters may generate the heading IDs differently as mentioned in the original PR linked above,.

**Before :x:**

The correct anchor link is: https://textual.textualize.io/FAQ/#why-doesnt-the-datatable-scroll-programmatically

Currently this link is broken in [automated responses](https://github.com/Textualize/textual/issues/4026#issuecomment-1892754619) because the backticks in the title are included in the slug:

```
why-doesn't-the-`datatable`-scroll-programmatically
```

**After :white_check_mark:**

```
why-doesnt-the-datatable-scroll-programmatically
```
